### PR TITLE
Report API Done (not editted)

### DIFF
--- a/src/main/java/hackerthon/likelion13th/canfly/domain/entity/Achievement.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/domain/entity/Achievement.java
@@ -1,8 +1,0 @@
-package hackerthon.likelion13th.canfly.domain.entity;
-
-public enum Achievement {
-    A,
-    B,
-    C,
-    D,
-}

--- a/src/main/java/hackerthon/likelion13th/canfly/domain/entity/CategoryName.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/domain/entity/CategoryName.java
@@ -1,0 +1,10 @@
+package hackerthon.likelion13th.canfly.domain.entity;
+
+public enum CategoryName {
+    KOREAN,
+    MATH,
+    ENGLISH,
+    KHISTORY,
+    SOCIAL,
+    SCIENCE,
+}

--- a/src/main/java/hackerthon/likelion13th/canfly/domain/report/Report.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/domain/report/Report.java
@@ -2,6 +2,8 @@ package hackerthon.likelion13th.canfly.domain.report;
 
 import hackerthon.likelion13th.canfly.domain.entity.BaseEntity;
 import hackerthon.likelion13th.canfly.domain.user.User;
+import hackerthon.likelion13th.canfly.domain.entity.CategoryName;
+import hackerthon.likelion13th.canfly.grades.dto.ReportResponseDto;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
@@ -24,16 +26,29 @@ public class Report extends BaseEntity {
     @Column(name = "rId")
     private Long id;
 
+    @Column(name = "user_grade", nullable = false)
+    private Integer userGrade;
+
+    @Column(name = "term", nullable = false)
+    private Integer term;
+
     /** 과목 카테고리명 (국어/수학) */
     @Column(name = "category_name", nullable = false)
-    private Integer categoryName;
+    @Enumerated(EnumType.STRING)
+    private CategoryName categoryName;
 
     /** 카테고리 평균 성적(예: 3.75) */
     @Column(name = "category_grade", precision = 5, scale = 2)
     private BigDecimal categoryGrade;
 
+
     @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ReportScore> scoreList = new ArrayList<>();
+    @Builder.Default
+    private List<ReportScore> scoreLists = new ArrayList<>();
+    public void addReportScore(ReportScore reportScore) {
+        this.scoreLists.add(reportScore);
+        reportScore.setReport(this);
+    }
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uid", nullable = false)

--- a/src/main/java/hackerthon/likelion13th/canfly/domain/report/ReportScore.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/domain/report/ReportScore.java
@@ -1,12 +1,11 @@
 package hackerthon.likelion13th.canfly.domain.report;
 
-import hackerthon.likelion13th.canfly.domain.entity.Achievement;
 import hackerthon.likelion13th.canfly.domain.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-import software.amazon.ion.Decimal;
+import java.math.BigDecimal;
 
 @Entity
 @Table(name = "reportScore")
@@ -33,27 +32,20 @@ public class ReportScore extends BaseEntity {
     @Column(name = "student_num")
     private Integer studentNum;      // 수강자 수
 
-    @Column(name = "standard_deviation", length = 50)
-    private Decimal standardDeviation;// 표준편차
+    @Column(name = "standard_deviation", precision = 4, scale = 1)
+    private BigDecimal standardDeviation;// 표준편차
 
-    @Column(name = "subject_average", length = 50)
+    @Column(name = "subject_average")
     private Integer subjectAverage;   // 평균
 
-    @Column(name = "achievement", length = 50)
-    @Enumerated(EnumType.STRING)
-    private Achievement achievement;      // 성취도(A,B,C)
+    @Column(name = "achievement")
+    private String achievement;// 성취도(A,B,C)
 
-    @Column(name = "score", length = 50)
+    @Column(name = "score")
     private Integer score;            // 원점수
 
-    @Column(name = "term", nullable = false)
-    private Integer term;            // 학기 구분
-
     @Column(name = "credit", nullable = false)
-    private Integer credit;          // 학점
-
-    @Column(name = "choice")
-    private Integer choice;          // 선택구분(일선/진선)
+    private Integer credit;          // 학점      // 선택구분(일선/진선)
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "rId", nullable = false)

--- a/src/main/java/hackerthon/likelion13th/canfly/domain/user/User.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/domain/user/User.java
@@ -59,22 +59,6 @@ public class User extends BaseEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Hmt> hmtResult = new ArrayList<>();
-    public void addHmt(Hmt hmt) {
-        this.hmtResult.add(hmt);
-        hmt.setUser(this);
-    }
-
-    @Builder.Default
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Cst> cstResult = new ArrayList<>();
-    public void addCst(Cst cst) {
-        this.cstResult.add(cst);
-        cst.setUser(this);
-    }
-
-    @Builder.Default
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FieldBookmark> fieldBookmarkList = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/hackerthon/likelion13th/canfly/domain/user/User.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/domain/user/User.java
@@ -51,6 +51,7 @@ public class User extends BaseEntity {
     private Byte gradeNum;
 
     @Column(nullable = false)
+    @Builder.Default
     private int token = 30;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/hackerthon/likelion13th/canfly/global/api/SuccessCode.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/global/api/SuccessCode.java
@@ -15,16 +15,29 @@ public enum SuccessCode implements BaseCode { // 성공
     USER_REISSUE_SUCCESS(HttpStatus.OK, "USER_2002", "토큰 재발급이 완료되었습니다."),
     USER_DELETE_SUCCESS(HttpStatus.OK, "USER_2003", "회원탈퇴가 완료되었습니다."),
 
-    MOCK_CREATE_SUCCESS(HttpStatus.OK, "MOCK_2011", "모의고사 등록이 완료되었습니다."),
-    MOCKSCORE_CREATE_SUCCESS(HttpStatus.OK, "MOCKSCORE_2011", "모의고사 성적 등록이 완료되었습니다."),
-    MOCK_DELETE_SUCCESS(HttpStatus.OK, "MOCK_2002", "모의고사 삭제가 완료되었습니다."),
+    MOCK_CREATE_SUCCESS(HttpStatus.CREATED, "MOCK_2011", "모의고사 등록이 완료되었습니다."),
+    MOCKSCORE_CREATE_SUCCESS(HttpStatus.CREATED, "MOCKSCORE_2011", "모의고사 성적 등록이 완료되었습니다."),
+    MOCK_PUT_SUCCESS(HttpStatus.OK, "MOCK_2012", "모의고사 정보 수정이 완료되었습니다.."),
+    MOCKSCORE_PUT_SUCCESS(HttpStatus.OK, "MOCKSCORE_2012", "모의고사 성적 수정이 완료되었습니다.."),
+    MOCK_GET_SUCCESS(HttpStatus.OK, "MOCK_2001", "모의고사 조회가 완료되었습니다."),
+    MOCK_GET_ALL_SUCCESS(HttpStatus.OK, "MOCK_2002", "모의고사 전체 조회가 완료되었습니다."),
+    MOCKSCORE_GET_SUCCESS(HttpStatus.OK, "MOCKSCORE_2001", "모의고사 성적 조회가 완료되었습니다."),
+    MOCK_DELETE_SUCCESS(HttpStatus.OK, "MOCK_2004", "모의고사 삭제가 완료되었습니다."),
 
     REPORT_CREATE_SUCCESS(HttpStatus.OK, "REPORT_2011", "내신 등록이 완료되었습니다."),
-    REPORTSCORE_CREATE_SUCCESS(HttpStatus.OK, "REPORTSCORE_2012", "내신 성적 등록이 완료되었습니다"),
+    REPORTSCORE_CREATE_SUCCESS(HttpStatus.OK, "REPORTSCORE_2011", "내신 성적 등록이 완료되었습니다"),
+    REPORT_PUT_SUCCESS(HttpStatus.OK, "REPORT_2012", "내신 수정이 완료되었습니다."),
+    REPORTSCORE_PUT_SUCCESS(HttpStatus.OK, "REPORTSCORE_2012", "내신 성적 수정이 완료되었습니다."),
+    REPORT_GET_SUCCESS(HttpStatus.OK, "REPORT_2001", "내신 정보 조회가 완료되었습니다.."),
+    REPORT_GET_ALL_SUCCESS(HttpStatus.OK, "REPORT_2002", "전체 내신 정보 조회가 완료되었습니다.."),
+    REPORTSCORE_GET_SUCCESS(HttpStatus.OK, "REPORTSCORE_2001", "내신 점수 조회가 완료되었습니다."),
     REPORT_DELETE_SUCCESS(HttpStatus.OK, "REPORT_2004", "내신 삭제가 완료되었습니다.."),
 
-    MAJORSYNC_BULK_SUCCESS(HttpStatus.OK, "Sync_2012", "DB 동기화가 완료되었습니다.");
+    // 형이 추가한 코드
+    MAJORSYNC_BULK_SUCCESS(HttpStatus.OK, "Sync_2012", "DB 동기화가 완료되었습니다."),
 
+    // 내가 추가한 코드
+    TOKEN_PROCESS_SUCCESS(HttpStatus.OK, "TOKEN_2001", "코인(토큰) 사용이 완료되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/hackerthon/likelion13th/canfly/global/api/SuccessCode.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/global/api/SuccessCode.java
@@ -16,8 +16,12 @@ public enum SuccessCode implements BaseCode { // 성공
     USER_DELETE_SUCCESS(HttpStatus.OK, "USER_2003", "회원탈퇴가 완료되었습니다."),
 
     MOCK_CREATE_SUCCESS(HttpStatus.OK, "MOCK_2011", "모의고사 등록이 완료되었습니다."),
-    MOCKSCORE_CREATE_SUCCESS(HttpStatus.OK, "MOCKSCORE_2011", "모의고사 성적 등록이 완료되었습니다."),
-    MOCK_DELETE_SUCCESS(HttpStatus.OK, "MOCK_2002", "모의고사 삭제가 완료되었습니다.");
+    MOCKSCORE_CREATE_SUCCESS(HttpStatus.OK, "MOCKSCORE_2012", "모의고사 성적 등록이 완료되었습니다."),
+    MOCK_DELETE_SUCCESS(HttpStatus.OK, "MOCK_2004", "모의고사 삭제가 완료되었습니다."),
+
+    REPORT_CREATE_SUCCESS(HttpStatus.OK, "REPORT_2011", "내신 등록이 완료되었습니다."),
+    REPORTSCORE_CREATE_SUCCESS(HttpStatus.OK, "REPORTSCORE_2012", "내신 성적 등록이 완료되었습니다"),
+    REPORT_DELETE_SUCCESS(HttpStatus.OK, "REPORT_2004", "내신 삭제가 완료되었습니다..");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hackerthon/likelion13th/canfly/global/config/WebConfig.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/global/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**") // 애플리케이션의 모든 API 경로에 대해 CORS 설정을 적용합니다.
                 .allowedOrigins("http://localhost:8080", "http://127.0.0.1:8080") // 로컬 환경의 Swagger UI
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드를 지정합니다.
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH") // 허용할 HTTP 메서드를 지정합니다.
                 .allowedHeaders("*") // 모든 HTTP 헤더를 허용합니다.
                 .allowCredentials(true); // 쿠키 및 인증 정보를 포함한 요청을 허용합니다.
     }

--- a/src/main/java/hackerthon/likelion13th/canfly/global/config/WebConfig.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/global/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**") // 애플리케이션의 모든 API 경로에 대해 CORS 설정을 적용합니다.
-                .allowedOrigins("http://localhost:8080", "http://127.0.0.1:8080") // 로컬 환경의 Swagger UIからのリクエストを許可します。
+                .allowedOrigins("http://localhost:8080", "http://127.0.0.1:8080") // 로컬 환경의 Swagger UI
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드를 지정합니다.
                 .allowedHeaders("*") // 모든 HTTP 헤더를 허용합니다.
                 .allowCredentials(true); // 쿠키 및 인증 정보를 포함한 요청을 허용합니다.

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/controller/MockController.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/controller/MockController.java
@@ -1,9 +1,7 @@
 package hackerthon.likelion13th.canfly.grades.controller;
 
 import hackerthon.likelion13th.canfly.domain.user.User;
-import hackerthon.likelion13th.canfly.global.api.ErrorCode;
 import hackerthon.likelion13th.canfly.global.api.SuccessCode;
-import hackerthon.likelion13th.canfly.global.exception.GeneralException;
 import hackerthon.likelion13th.canfly.grades.dto.MockRequestDto;
 import hackerthon.likelion13th.canfly.grades.dto.MockResponseDto;
 import hackerthon.likelion13th.canfly.grades.service.MockService;
@@ -13,13 +11,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -54,7 +49,7 @@ public class MockController {
     @PostMapping("/{mockId}")
     @Operation(summary = "모의고사 점수 등록", description = "어떤 모의고사의 특정 과목 성적을 입력하는 메서드입니다..")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mock_2012", description = "모의고사 성적 등록이 완료되었습니다."),
+            @ApiResponse(responseCode = "Mockscore_2012", description = "모의고사 성적 등록이 완료되었습니다."),
     })
     public hackerthon.likelion13th.canfly.global.api.ApiResponse<MockResponseDto> createMockScoreLists(
             @PathVariable Long mockId,
@@ -89,7 +84,7 @@ public class MockController {
     @GetMapping("/{mockId}/{mockScoreId}")
     @Operation(summary = "모의고사 내 특정 과목 성적 조회", description = "특정 과목의 성적을 조회하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mock_2003", description = "과목 성적 조회가 완료되었습니다."),
+            @ApiResponse(responseCode = "Mockscore_2003", description = "과목 성적 조회가 완료되었습니다."),
     })
     public ResponseEntity<MockResponseDto.MockScoreResponseDto> getMockScore(@PathVariable Long mockId, @PathVariable Long mockScoreId) {
         MockResponseDto.MockScoreResponseDto mockScore = mockService.getMockScoreById(mockId, mockScoreId);
@@ -109,7 +104,7 @@ public class MockController {
     @PutMapping("/{mockId}/{mockScoreId}")
     @Operation(summary = "모의고사 성적 수정", description = "특정 모의고사의 성적을 수정하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mock_2014", description = "모의고사 성적 수정이 완료되었습니다."),
+            @ApiResponse(responseCode = "Mockscore_2014", description = "모의고사 성적 수정이 완료되었습니다."),
     })
     public ResponseEntity<MockResponseDto.MockScoreResponseDto> updateMockScore(@PathVariable Long mockId, @PathVariable Long mockScoreId, @RequestBody MockRequestDto.MockScoreRequestDto mockScoreRequestDto) {
         MockResponseDto.MockScoreResponseDto responseDto = mockService.updateMockScore(mockId, mockScoreRequestDto);

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/controller/MockController.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/controller/MockController.java
@@ -1,6 +1,7 @@
 package hackerthon.likelion13th.canfly.grades.controller;
 
 import hackerthon.likelion13th.canfly.domain.user.User;
+import hackerthon.likelion13th.canfly.global.api.ApiResponse;
 import hackerthon.likelion13th.canfly.global.api.SuccessCode;
 import hackerthon.likelion13th.canfly.grades.dto.MockRequestDto;
 import hackerthon.likelion13th.canfly.grades.dto.MockResponseDto;
@@ -8,12 +9,10 @@ import hackerthon.likelion13th.canfly.grades.service.MockService;
 import hackerthon.likelion13th.canfly.login.auth.mapper.CustomUserDetails;
 import hackerthon.likelion13th.canfly.login.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,94 +32,97 @@ public class MockController {
     @PostMapping
     @Operation(summary = "모의고사 등록", description = "특정 년도, 월에 진행한 특정 학년의 모의고사를 등록하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mock_2011", description = "모의고사 등록이 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Mock_2011", description = "모의고사 등록이 완료되었습니다."),
     })
-    public hackerthon.likelion13th.canfly.global.api.ApiResponse<MockResponseDto> createMock(
+    public ApiResponse<MockResponseDto> createMock(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody MockRequestDto mockRequestDto) {
 
-        User user = userService.findUserByProviderId(customUserDetails.getUsername());
+        User user = userService.findUserByProviderId(customUserDetails.getProviderId());
         MockResponseDto dto = mockService.createMock(user.getUid(), mockRequestDto);
 
-        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.MOCK_CREATE_SUCCESS, dto);
+        return ApiResponse.onSuccess(SuccessCode.MOCK_CREATE_SUCCESS, dto);
+
     }
 
     @PostMapping("/{mockId}")
     @Operation(summary = "모의고사 점수 등록", description = "어떤 모의고사의 특정 과목 성적을 입력하는 메서드입니다..")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mockscore_2012", description = "모의고사 성적 등록이 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Mockscore_2012", description = "모의고사 성적 등록이 완료되었습니다."),
     })
-    public hackerthon.likelion13th.canfly.global.api.ApiResponse<MockResponseDto> createMockScoreLists(
+    public ApiResponse<MockResponseDto> createMockScoreLists(
             @PathVariable Long mockId,
             @RequestBody MockRequestDto.MockScoreRequestDto mockScoreRequestDto
             ) {
 
         MockResponseDto responseDto = mockService.addMockScoreToMock(mockId, mockScoreRequestDto);
-        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.MOCKSCORE_CREATE_SUCCESS, responseDto);
+        return ApiResponse.onSuccess(SuccessCode.MOCKSCORE_CREATE_SUCCESS, responseDto);
     }
 
     @GetMapping
     @Operation(summary = "전체 모의고사 조회", description = "사용자가 진행했던 모든 모의고사를 조회하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mock_2001", description = "전체 모의고사 조회가 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Mock_2001", description = "전체 모의고사 조회가 완료되었습니다."),
     })
-    public ResponseEntity<List<MockResponseDto>> getAllMocksOfUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+    public ApiResponse<List<MockResponseDto>> getAllMocksOfUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         /* providerId 기반으로 User 찾기 */
-        User user = userService.findUserByProviderId(customUserDetails.getUsername());
+        User user = userService.findUserByProviderId(customUserDetails.getProviderId());
         List<MockResponseDto> allMocks = mockService.getAllMocksByUserId(user.getUid());
 
-        return ResponseEntity.ok(allMocks);
+        return ApiResponse.onSuccess(SuccessCode.MOCK_GET_ALL_SUCCESS, allMocks);
+
     }
 
     @GetMapping("/{mockId}")
     @Operation(summary = "특정 모의고사 조회", description = "하나의 모의고사를 조회하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mock_2002", description = "모의고사 조회가 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Mock_2002", description = "모의고사 조회가 완료되었습니다."),
     })
-    public ResponseEntity<MockResponseDto> getMockById(@PathVariable Long mockId) {
+    public ApiResponse<MockResponseDto> getMockById(@PathVariable Long mockId) {
         MockResponseDto responseDto = mockService.getMockById(mockId);
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(SuccessCode.MOCK_GET_SUCCESS, responseDto);
     }
 
     @GetMapping("/{mockId}/{mockScoreId}")
     @Operation(summary = "모의고사 내 특정 과목 성적 조회", description = "특정 과목의 성적을 조회하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mockscore_2003", description = "과목 성적 조회가 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Mockscore_2003", description = "과목 성적 조회가 완료되었습니다."),
     })
-    public ResponseEntity<MockResponseDto.MockScoreResponseDto> getMockScore(@PathVariable Long mockId, @PathVariable Long mockScoreId) {
+    public ApiResponse<MockResponseDto.MockScoreResponseDto> getMockScore(@PathVariable Long mockId, @PathVariable Long mockScoreId) {
         MockResponseDto.MockScoreResponseDto mockScore = mockService.getMockScoreById(mockId, mockScoreId);
-        return ResponseEntity.ok(mockScore);
+        return ApiResponse.onSuccess(SuccessCode.MOCKSCORE_GET_SUCCESS, mockScore);
     }
 
     @PutMapping("/{mockId}")
     @Operation(summary = "모의고사 정보 수정", description = "특정 모의고사의 정보를 수정하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mock_2013", description = "특정 모의고사 정보 수정이 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Mock_2013", description = "특정 모의고사 정보 수정이 완료되었습니다."),
     })
-    public ResponseEntity<MockResponseDto> updateMock(@PathVariable Long mockId, @RequestBody MockRequestDto mockRequestDto) {
+    public ApiResponse<MockResponseDto> updateMock(@PathVariable Long mockId, @RequestBody MockRequestDto mockRequestDto) {
         MockResponseDto responseDto = mockService.updateMock(mockId, mockRequestDto);
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(SuccessCode.MOCK_PUT_SUCCESS, responseDto);
     }
 
     @PutMapping("/{mockId}/{mockScoreId}")
     @Operation(summary = "모의고사 성적 수정", description = "특정 모의고사의 성적을 수정하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mockscore_2014", description = "모의고사 성적 수정이 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Mockscore_2014", description = "모의고사 성적 수정이 완료되었습니다."),
     })
-    public ResponseEntity<MockResponseDto.MockScoreResponseDto> updateMockScore(@PathVariable Long mockId, @PathVariable Long mockScoreId, @RequestBody MockRequestDto.MockScoreRequestDto mockScoreRequestDto) {
+    public ApiResponse<MockResponseDto.MockScoreResponseDto> updateMockScore(@PathVariable Long mockId, @PathVariable Long mockScoreId, @RequestBody MockRequestDto.MockScoreRequestDto mockScoreRequestDto) {
         MockResponseDto.MockScoreResponseDto responseDto = mockService.updateMockScore(mockId, mockScoreRequestDto);
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(SuccessCode.MOCKSCORE_PUT_SUCCESS, responseDto);
     }
 
 
     @DeleteMapping("/{mockId}")
     @Operation(summary = "모의고사 삭제", description = "특정 모의고사를 삭제하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Mock_2004", description = "모의고사 삭제가 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Mock_2004", description = "모의고사 삭제가 완료되었습니다."),
     })
-    public hackerthon.likelion13th.canfly.global.api.ApiResponse<Boolean> deleteMock(@PathVariable Long mockId) {
+    public ApiResponse<Boolean> deleteMock(@PathVariable Long mockId) {
         mockService.deleteMock(mockId);
-        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.MOCK_DELETE_SUCCESS, true);
+        return ApiResponse.onSuccess(SuccessCode.MOCK_DELETE_SUCCESS, true);
     }
 
 }

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/controller/ReportController.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/controller/ReportController.java
@@ -1,5 +1,125 @@
 package hackerthon.likelion13th.canfly.grades.controller;
 
+import hackerthon.likelion13th.canfly.domain.user.User;
+import hackerthon.likelion13th.canfly.global.api.SuccessCode;
+import hackerthon.likelion13th.canfly.grades.dto.ReportRequestDto;
+import hackerthon.likelion13th.canfly.grades.dto.ReportResponseDto;
+import hackerthon.likelion13th.canfly.grades.service.ReportService;
+import hackerthon.likelion13th.canfly.login.auth.mapper.CustomUserDetails;
+import hackerthon.likelion13th.canfly.login.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@Tag(name="내신", description = "내신 성적 입력 컨트롤러입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/grades/report")
+@Slf4j
 public class ReportController {
+
+    private final ReportService reportService;
+    private final UserService userService;
+
+
+    @PostMapping
+    @Operation(summary = "내신 등록", description = "특정 년도, 월에 진행한 특정 학년의 내신를 등록하는 메서드입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "Report_2011", description = "내신 등록이 완료되었습니다."),
+    })
+    public hackerthon.likelion13th.canfly.global.api.ApiResponse<ReportResponseDto> createReport(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody ReportRequestDto reportRequestDto) {
+
+
+        User user = userService.findUserByUserName(customUserDetails.getUsername());
+        String userId = user.getUid();
+
+        ReportResponseDto responseDto = reportService.createReport(userId, reportRequestDto);
+        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.REPORT_CREATE_SUCCESS, responseDto);
+    }
+
+    @PostMapping("/{reportId}")
+    @Operation(summary = "내신 점수 등록", description = "어떤 내신의 특정 과목 성적을 입력하는 메서드입니다..")
+    @ApiResponses({
+            @ApiResponse(responseCode = "Report_2012", description = "내신 성적 등록이 완료되었습니다."),
+    })
+    public hackerthon.likelion13th.canfly.global.api.ApiResponse<ReportResponseDto> createReportScoreLists(
+            @PathVariable Long reportId,
+            @RequestBody ReportRequestDto.ReportScoreRequestDto reportScoreRequestDto
+    ) {
+
+        ReportResponseDto responseDto = reportService.addReportScoreToReport(reportId, reportScoreRequestDto);
+        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.REPORTSCORE_CREATE_SUCCESS, responseDto);
+    }
+
+    @GetMapping
+    @Operation(summary = "전체 내신 조회", description = "사용자가 진행했던 모든 내신를 조회하는 메서드입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "Report_2001", description = "전체 내신 조회가 완료되었습니다."),
+    })
+    public ResponseEntity<List<ReportResponseDto>> getAllReportsOfUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        User user = userService.findUserByUserName(customUserDetails.getUsername());
+        List<ReportResponseDto> allReports = reportService.getAllReportsByUserId(user.getUid());
+        return ResponseEntity.ok(allReports);
+    }
+
+    @GetMapping("/{reportId}")
+    @Operation(summary = "특정 내신 조회", description = "하나의 내신를 조회하는 메서드입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "Report_2002", description = "내신 조회가 완료되었습니다."),
+    })
+    public ResponseEntity<ReportResponseDto> getReportById(@PathVariable Long reportId) {
+        ReportResponseDto responseDto = reportService.getReportById(reportId);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{reportId}/{reportScoreId}")
+    @Operation(summary = "내신 내 특정 과목 성적 조회", description = "특정 과목의 성적을 조회하는 메서드입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "Report_2003", description = "과목 성적 조회가 완료되었습니다."),
+    })
+    public ResponseEntity<ReportResponseDto.ReportScoreResponseDto> getReportScore(@PathVariable Long reportId, @PathVariable Long reportScoreId) {
+        ReportResponseDto.ReportScoreResponseDto reportScore = reportService.getReportScoreById(reportId, reportScoreId);
+        return ResponseEntity.ok(reportScore);
+    }
+
+    @PutMapping("/{reportId}")
+    @Operation(summary = "내신 정보 수정", description = "특정 내신의 정보를 수정하는 메서드입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "Report_2013", description = "특정 내신 정보 수정이 완료되었습니다."),
+    })
+    public ResponseEntity<ReportResponseDto> updateReport(@PathVariable Long reportId, @RequestBody ReportRequestDto reportRequestDto) {
+        ReportResponseDto responseDto = reportService.updateReport(reportId, reportRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PutMapping("/{reportId}/{reportScoreId}")
+    @Operation(summary = "내신 성적 수정", description = "특정 내신의 성적을 수정하는 메서드입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "Report_2014", description = "내신 성적 수정이 완료되었습니다."),
+    })
+    public ResponseEntity<ReportResponseDto.ReportScoreResponseDto> updateReportScore(@PathVariable Long reportId, @PathVariable Long reportScoreId, @RequestBody ReportRequestDto.ReportScoreRequestDto reportScoreRequestDto) {
+        ReportResponseDto.ReportScoreResponseDto responseDto = reportService.updateReportScore(reportScoreId, reportScoreRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+
+    @DeleteMapping("/{reportId}")
+    @Operation(summary = "내신 삭제", description = "특정 내신를 삭제하는 메서드입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "Report_2004", description = "내신 삭제가 완료되었습니다."),
+    })
+    public hackerthon.likelion13th.canfly.global.api.ApiResponse<Boolean> deleteReport(@PathVariable Long reportId) {
+        reportService.deleteReport(reportId);
+        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.REPORT_DELETE_SUCCESS, true);
+    }
 
 }

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/controller/ReportController.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/controller/ReportController.java
@@ -2,18 +2,17 @@ package hackerthon.likelion13th.canfly.grades.controller;
 
 import hackerthon.likelion13th.canfly.domain.user.User;
 import hackerthon.likelion13th.canfly.global.api.SuccessCode;
+import hackerthon.likelion13th.canfly.global.api.ApiResponse;
 import hackerthon.likelion13th.canfly.grades.dto.ReportRequestDto;
 import hackerthon.likelion13th.canfly.grades.dto.ReportResponseDto;
 import hackerthon.likelion13th.canfly.grades.service.ReportService;
 import hackerthon.likelion13th.canfly.login.auth.mapper.CustomUserDetails;
 import hackerthon.likelion13th.canfly.login.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -32,94 +31,93 @@ public class ReportController {
     @PostMapping
     @Operation(summary = "내신 등록", description = "특정 년도, 월에 진행한 특정 학년의 내신를 등록하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Report_2011", description = "내신 등록이 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Report_2011", description = "내신 등록이 완료되었습니다."),
     })
-    public hackerthon.likelion13th.canfly.global.api.ApiResponse<ReportResponseDto> createReport(
+    public ApiResponse<ReportResponseDto> createReport(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody ReportRequestDto reportRequestDto) {
 
 
         User user = userService.findUserByUserName(customUserDetails.getUsername());
-        String userId = user.getUid();
 
-        ReportResponseDto responseDto = reportService.createReport(userId, reportRequestDto);
-        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.REPORT_CREATE_SUCCESS, responseDto);
+        ReportResponseDto responseDto = reportService.createReport(user.getName(), reportRequestDto);
+        return ApiResponse.onSuccess(SuccessCode.REPORT_CREATE_SUCCESS, responseDto);
     }
 
     @PostMapping("/{reportId}")
     @Operation(summary = "내신 점수 등록", description = "어떤 내신의 특정 과목 성적을 입력하는 메서드입니다..")
     @ApiResponses({
-            @ApiResponse(responseCode = "Report_2012", description = "내신 성적 등록이 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Report_2012", description = "내신 성적 등록이 완료되었습니다."),
     })
-    public hackerthon.likelion13th.canfly.global.api.ApiResponse<ReportResponseDto> createReportScoreLists(
+    public ApiResponse<ReportResponseDto> createReportScoreLists(
             @PathVariable Long reportId,
             @RequestBody ReportRequestDto.ReportScoreRequestDto reportScoreRequestDto
     ) {
 
         ReportResponseDto responseDto = reportService.addReportScoreToReport(reportId, reportScoreRequestDto);
-        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.REPORTSCORE_CREATE_SUCCESS, responseDto);
+        return ApiResponse.onSuccess(SuccessCode.REPORTSCORE_CREATE_SUCCESS, responseDto);
     }
 
     @GetMapping
     @Operation(summary = "전체 내신 조회", description = "사용자가 진행했던 모든 내신를 조회하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Report_2001", description = "전체 내신 조회가 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Report_2001", description = "전체 내신 조회가 완료되었습니다."),
     })
-    public ResponseEntity<List<ReportResponseDto>> getAllReportsOfUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ApiResponse<List<ReportResponseDto>> getAllReportsOfUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         User user = userService.findUserByUserName(customUserDetails.getUsername());
-        List<ReportResponseDto> allReports = reportService.getAllReportsByUserId(user.getUid());
-        return ResponseEntity.ok(allReports);
+        List<ReportResponseDto> allReports = reportService.getAllReportsByUserName(user.getName());
+        return ApiResponse.onSuccess(SuccessCode.REPORT_GET_ALL_SUCCESS, allReports);
     }
 
     @GetMapping("/{reportId}")
     @Operation(summary = "특정 내신 조회", description = "하나의 내신를 조회하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Report_2002", description = "내신 조회가 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Report_2002", description = "내신 조회가 완료되었습니다."),
     })
-    public ResponseEntity<ReportResponseDto> getReportById(@PathVariable Long reportId) {
+    public ApiResponse<ReportResponseDto> getReportById(@PathVariable Long reportId) {
         ReportResponseDto responseDto = reportService.getReportById(reportId);
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(SuccessCode.REPORT_GET_SUCCESS, responseDto);
     }
 
     @GetMapping("/{reportId}/{reportScoreId}")
     @Operation(summary = "내신 내 특정 과목 성적 조회", description = "특정 과목의 성적을 조회하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Report_2003", description = "과목 성적 조회가 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Report_2003", description = "과목 성적 조회가 완료되었습니다."),
     })
-    public ResponseEntity<ReportResponseDto.ReportScoreResponseDto> getReportScore(@PathVariable Long reportId, @PathVariable Long reportScoreId) {
+    public ApiResponse<ReportResponseDto.ReportScoreResponseDto> getReportScore(@PathVariable Long reportId, @PathVariable Long reportScoreId) {
         ReportResponseDto.ReportScoreResponseDto reportScore = reportService.getReportScoreById(reportId, reportScoreId);
-        return ResponseEntity.ok(reportScore);
+        return ApiResponse.onSuccess(SuccessCode.REPORTSCORE_GET_SUCCESS, reportScore);
     }
 
     @PutMapping("/{reportId}")
-    @Operation(summary = "내신 정보 수정", description = "특정 내신의 정보를 수정하는 메서드입니다.")
+    @Operation(summary = "내신 정보 수정", description = "특정 내신의 정보를 수정하는 메서드입니다.") //※ 규칙: 여기에서 절대로 CategoryName은 건들면 안됨
     @ApiResponses({
-            @ApiResponse(responseCode = "Report_2013", description = "특정 내신 정보 수정이 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Report_2013", description = "특정 내신 정보 수정이 완료되었습니다."),
     })
-    public ResponseEntity<ReportResponseDto> updateReport(@PathVariable Long reportId, @RequestBody ReportRequestDto reportRequestDto) {
+    public ApiResponse<ReportResponseDto> updateReport(@PathVariable Long reportId, @RequestBody ReportRequestDto reportRequestDto) {
         ReportResponseDto responseDto = reportService.updateReport(reportId, reportRequestDto);
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(SuccessCode.REPORT_PUT_SUCCESS, responseDto);
     }
 
     @PutMapping("/{reportId}/{reportScoreId}")
     @Operation(summary = "내신 성적 수정", description = "특정 내신의 성적을 수정하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Report_2014", description = "내신 성적 수정이 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Report_2014", description = "내신 성적 수정이 완료되었습니다."),
     })
-    public ResponseEntity<ReportResponseDto.ReportScoreResponseDto> updateReportScore(@PathVariable Long reportId, @PathVariable Long reportScoreId, @RequestBody ReportRequestDto.ReportScoreRequestDto reportScoreRequestDto) {
+    public ApiResponse<ReportResponseDto.ReportScoreResponseDto> updateReportScore(@PathVariable Long reportId, @PathVariable Long reportScoreId, @RequestBody ReportRequestDto.ReportScoreRequestDto reportScoreRequestDto) {
         ReportResponseDto.ReportScoreResponseDto responseDto = reportService.updateReportScore(reportScoreId, reportScoreRequestDto);
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(SuccessCode.REPORTSCORE_PUT_SUCCESS, responseDto);
     }
 
 
     @DeleteMapping("/{reportId}")
     @Operation(summary = "내신 삭제", description = "특정 내신를 삭제하는 메서드입니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "Report_2004", description = "내신 삭제가 완료되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "Report_2004", description = "내신 삭제가 완료되었습니다."),
     })
-    public hackerthon.likelion13th.canfly.global.api.ApiResponse<Boolean> deleteReport(@PathVariable Long reportId) {
+    public ApiResponse<Boolean> deleteReport(@PathVariable Long reportId) {
         reportService.deleteReport(reportId);
-        return hackerthon.likelion13th.canfly.global.api.ApiResponse.onSuccess(SuccessCode.REPORT_DELETE_SUCCESS, true);
+        return ApiResponse.onSuccess(SuccessCode.REPORT_DELETE_SUCCESS, true);
     }
 
 }

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/dto/MockResponseDto.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/dto/MockResponseDto.java
@@ -2,16 +2,10 @@ package hackerthon.likelion13th.canfly.grades.dto;
 
 import hackerthon.likelion13th.canfly.domain.mock.Mock;
 import hackerthon.likelion13th.canfly.domain.mock.MockScore;
-import hackerthon.likelion13th.canfly.domain.user.User;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-import org.springframework.data.relational.core.sql.In;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/dto/ReportRequestDto.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/dto/ReportRequestDto.java
@@ -1,4 +1,36 @@
 package hackerthon.likelion13th.canfly.grades.dto;
 
+import hackerthon.likelion13th.canfly.domain.entity.CategoryName;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReportRequestDto {
+    private Integer userGrade;
+    private Integer term;
+    private CategoryName categoryName;
+    private BigDecimal categoryGrade;
+    private List<ReportScoreRequestDto> scoreLists;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReportScoreRequestDto {
+        private String subject;
+        private Integer grade;
+        private Integer ranking;
+        private Integer studentNum;
+        private BigDecimal standardDeviation;
+        private Integer subjectAverage;
+        private String achievement;
+        private Integer score;
+        private Integer credit;
+    }
 }

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/dto/ReportResponseDto.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/dto/ReportResponseDto.java
@@ -1,4 +1,65 @@
 package hackerthon.likelion13th.canfly.grades.dto;
 
+import hackerthon.likelion13th.canfly.domain.entity.CategoryName;
+import hackerthon.likelion13th.canfly.domain.report.Report;
+import hackerthon.likelion13th.canfly.domain.report.ReportScore;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReportResponseDto {
+    private Long id;
+    private Integer userGrade;
+    private Integer term;
+    private CategoryName categoryName;
+    private BigDecimal categoryGrade;
+    private List<ReportScoreResponseDto> scoreList = new ArrayList<>();
+
+    public ReportResponseDto(Report report) {
+        this.id = report.getId();
+        this.userGrade = report.getUserGrade();
+        this.term = report.getTerm();
+        this.categoryName = report.getCategoryName();
+        this.categoryGrade = report.getCategoryGrade();
+        this.scoreList = report.getScoreLists().stream()
+                        .map(ReportScoreResponseDto::new) // ReportScoreResponseDto의 생성자 호출
+                        .collect(Collectors.toList());
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReportScoreResponseDto {
+        private Long scoreId;
+        private String subject;
+        private Integer grade;
+        private Integer ranking;
+        private Integer studentNum;
+        private BigDecimal standardDeviation;
+        private Integer subjectAverage;
+        private String achievement;
+        private Integer score;
+        private Integer credit;
+
+        public ReportScoreResponseDto(ReportScore reportScore) {
+            this.scoreId = reportScore.getId();
+            this.subject = reportScore.getSubject();
+            this.grade = reportScore.getGrade();
+            this.ranking = reportScore.getRanking();
+            this.studentNum = reportScore.getStudentNum();
+            this.standardDeviation = reportScore.getStandardDeviation();
+            this.subjectAverage = reportScore.getSubjectAverage();
+            this.score = reportScore.getScore();
+            this.credit = reportScore.getCredit();
+        }
+    }
 }

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/dto/ReportResponseDto.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/dto/ReportResponseDto.java
@@ -58,6 +58,7 @@ public class ReportResponseDto {
             this.studentNum = reportScore.getStudentNum();
             this.standardDeviation = reportScore.getStandardDeviation();
             this.subjectAverage = reportScore.getSubjectAverage();
+            this.achievement = reportScore.getAchievement();
             this.score = reportScore.getScore();
             this.credit = reportScore.getCredit();
         }

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/repository/MockRepository.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/repository/MockRepository.java
@@ -5,6 +5,7 @@ import hackerthon.likelion13th.canfly.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MockRepository extends JpaRepository<Mock, Long> {
 

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/repository/ReportRepository.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/repository/ReportRepository.java
@@ -1,9 +1,13 @@
 package hackerthon.likelion13th.canfly.grades.repository;
 
 import hackerthon.likelion13th.canfly.domain.report.Report;
+import hackerthon.likelion13th.canfly.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
 
+    List<Report> findByUser(User user);
 }

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/repository/ReportScoreRepository.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/repository/ReportScoreRepository.java
@@ -1,12 +1,12 @@
 package hackerthon.likelion13th.canfly.grades.repository;
 
-import hackerthon.likelion13th.canfly.domain.mock.MockScore;
-import hackerthon.likelion13th.canfly.domain.report.Report;
 import hackerthon.likelion13th.canfly.domain.report.ReportScore;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReportScoreRepository extends JpaRepository<ReportScore, Long> {
     Optional<ReportScore> findById(Long id);
+    List<ReportScore> findByReportId(Long reportId);
 }

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/service/MockService.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/service/MockService.java
@@ -10,17 +10,13 @@ import hackerthon.likelion13th.canfly.grades.dto.MockRequestDto;
 import hackerthon.likelion13th.canfly.grades.dto.MockResponseDto;
 import hackerthon.likelion13th.canfly.grades.repository.MockRepository;
 import hackerthon.likelion13th.canfly.grades.repository.MockScoreRepository;
-import hackerthon.likelion13th.canfly.login.auth.mapper.CustomUserDetails;
 import hackerthon.likelion13th.canfly.login.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/service/MockService.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/service/MockService.java
@@ -81,6 +81,7 @@ public class MockService {
                 .name(scoreRequestDto.getName())
                 .build();
         mock.addMockScore(newMockScore); // Mock 엔티티에 MockScore 추가 (양방향 관계 설정)
+        mockScoreRepository.save(newMockScore);
         return new MockResponseDto(mock);
     }
 

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/service/MockService.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/service/MockService.java
@@ -28,16 +28,11 @@ public class MockService {
     private final MockScoreRepository mockScoreRepository;
     private final UserRepository userRepository;
 
-    @Transactional
-    public Mock findById(Long mockId) {
-        return mockRepository.findById(mockId)
-                .orElseThrow(() -> GeneralException.of(ErrorCode.MOCK_NOT_FOUND));
-    }
 
     @Transactional
-    public MockResponseDto createMock(String userId, MockRequestDto mockRequestDto) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + userId));
+    public MockResponseDto createMock(String userName, MockRequestDto mockRequestDto) {
+        User user = userRepository.findByName(userName)
+                .orElseThrow(() -> GeneralException.of(ErrorCode.USER_NOT_FOUND));
 
         Mock newMock = Mock.builder()
                 .examYear(mockRequestDto.getExamYear())
@@ -98,7 +93,7 @@ public class MockService {
             throw new IllegalArgumentException("User not found with id: " + userId);
         }
 
-        List<Mock> mocks = mockRepository.findByUser(userRepository.findByUid(userId));
+        List<Mock> mocks = mockRepository.findByUser(userRepository.findByUid(userId).orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId)));
 
         return mocks.stream()
                 .map(this::convertToDto)

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/service/ReportService.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/service/ReportService.java
@@ -63,6 +63,7 @@ public class ReportService {
             }
         }
         user.addReport(newReport);
+        reportRepository.save(newReport);
         return new ReportResponseDto(newReport);
     }
 
@@ -85,6 +86,7 @@ public class ReportService {
                 .build();
         report.setCategoryGrade(getAverageReportScore(report.getId()));
         report.addReportScore(newReportScore); // Report 엔티티에 ReportScore 추가 (양방향 관계 설정)
+        reportScoreRepository.save(newReportScore);
         return new ReportResponseDto(report);
     }
 

--- a/src/main/java/hackerthon/likelion13th/canfly/grades/service/ReportService.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/grades/service/ReportService.java
@@ -1,12 +1,189 @@
 package hackerthon.likelion13th.canfly.grades.service;
 
+
+import hackerthon.likelion13th.canfly.domain.report.Report;
+import hackerthon.likelion13th.canfly.domain.report.ReportScore;
+import hackerthon.likelion13th.canfly.domain.user.User;
+import hackerthon.likelion13th.canfly.global.api.ErrorCode;
+import hackerthon.likelion13th.canfly.global.exception.GeneralException;
+import hackerthon.likelion13th.canfly.grades.dto.ReportRequestDto;
+import hackerthon.likelion13th.canfly.grades.dto.ReportResponseDto;
 import hackerthon.likelion13th.canfly.grades.repository.ReportRepository;
 import hackerthon.likelion13th.canfly.grades.repository.ReportScoreRepository;
 import hackerthon.likelion13th.canfly.login.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.OptionalDouble;
+import java.util.stream.Collectors;
+
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
 public class ReportService {
-//    private final ReportRepository reportRepository;
-//    private final UserRepository userRepository;
-//    private final ReportScoreRepository reportScoreRepository;
+    private final ReportRepository reportRepository;
+    private final ReportScoreRepository reportScoreRepository;
+    private final UserRepository userRepository;
 
+    @Transactional
+    public ReportResponseDto createReport(String userId, ReportRequestDto reportRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + userId));
+
+        Report newReport = Report.builder()
+                .categoryName(reportRequestDto.getCategoryName())
+                .categoryGrade(BigDecimal.valueOf(0.0))
+                .term(reportRequestDto.getTerm())
+                .userGrade(reportRequestDto.getUserGrade())
+                .user(user)
+                .build();
+
+        // ReportScoreRequestDto 리스트를 ReportScore 엔티티 리스트로 변환하여 추가
+        if (reportRequestDto.getScoreLists() != null && !reportRequestDto.getScoreLists().isEmpty()) {
+            for (ReportRequestDto.ReportScoreRequestDto scoreDto : reportRequestDto.getScoreLists()) {
+                ReportScore reportScore = ReportScore.builder()
+                        .subject(scoreDto.getSubject())
+                        .grade(scoreDto.getGrade())
+                        .achievement(scoreDto.getAchievement())
+                        .ranking(scoreDto.getRanking())
+                        .studentNum(scoreDto.getStudentNum())
+                        .standardDeviation(scoreDto.getStandardDeviation())
+                        .subjectAverage(scoreDto.getSubjectAverage())
+                        .score(scoreDto.getScore())
+                        .credit(scoreDto.getCredit())
+                        .build();
+                newReport.addReportScore(reportScore);
+            }
+        }
+        user.addReport(newReport);
+        return new ReportResponseDto(newReport);
+    }
+
+    @Transactional
+    public ReportResponseDto addReportScoreToReport(Long reportId, ReportRequestDto.ReportScoreRequestDto scoreRequestDto) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new IllegalArgumentException("Report not found with id: " + reportId));
+
+        // DTO 필드에서 ReportScore 엔티티 직접 생성
+        ReportScore newReportScore = ReportScore.builder()
+                .subject(scoreRequestDto.getSubject())
+                .grade(scoreRequestDto.getGrade())
+                .achievement(scoreRequestDto.getAchievement())
+                .ranking(scoreRequestDto.getRanking())
+                .studentNum(scoreRequestDto.getStudentNum())
+                .standardDeviation(scoreRequestDto.getStandardDeviation())
+                .subjectAverage(scoreRequestDto.getSubjectAverage())
+                .score(scoreRequestDto.getScore())
+                .credit(scoreRequestDto.getCredit())
+                .build();
+        report.setCategoryGrade(getAverageReportScore(report.getId()));
+        report.addReportScore(newReportScore); // Report 엔티티에 ReportScore 추가 (양방향 관계 설정)
+        return new ReportResponseDto(report);
+    }
+
+    @Transactional(readOnly = true)
+    public ReportResponseDto getReportById(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new IllegalArgumentException("Report not found with ID: " + reportId));
+        return new ReportResponseDto(report);
+    }
+
+    @Transactional
+    public List<ReportResponseDto> getAllReportsByUserId(String userId) {
+        if (!userRepository.existsById(userId)) {
+            throw new IllegalArgumentException("User not found with id: " + userId);
+        }
+
+        List<Report> reports = reportRepository.findByUser(userRepository.findByUid(userId));
+
+        return reports.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public ReportResponseDto.ReportScoreResponseDto getReportScoreById(Long reportId, Long scoreId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new IllegalArgumentException("Report not found with id: " + reportId));
+
+        ReportScore reportScore = report.getScoreLists().stream()
+                .filter(score -> score.getId().equals(scoreId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("ReportScore not found with id: " + scoreId + " in Report: " + reportId));
+
+        return new ReportResponseDto.ReportScoreResponseDto(reportScore);
+    }
+
+    @Transactional
+    public BigDecimal getAverageReportScore(Long reportId) {
+        // 리포트 존재 여부 확인 로직
+        // ...
+
+        List<ReportScore> scores = reportScoreRepository.findByReportId(reportId);
+
+        if (scores.isEmpty()) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal sum = scores.stream()
+                .map(ReportScore::getScore)         // Stream<Integer>
+                .map(BigDecimal::valueOf)           // 이 단계에서 Integer를 BigDecimal로 변환합니다.
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal count = BigDecimal.valueOf(scores.size());
+        BigDecimal average = sum.divide(count, MathContext.DECIMAL64);
+
+        // 3. 계산된 평균값의 소수점 자릿수를 2자리로 설정하고 반올림합니다.
+        return average.setScale(2, RoundingMode.HALF_UP);
+    }
+
+
+    @Transactional
+    public ReportResponseDto updateReport(Long reportId, ReportRequestDto reportRequestDto) {
+        Report existingReport = reportRepository.findById(reportId)
+                .orElseThrow(() -> new IllegalArgumentException("Report not found with id: " + reportId));
+        existingReport.setCategoryName(reportRequestDto.getCategoryName());
+        existingReport.setCategoryGrade(getAverageReportScore(reportId));
+        existingReport.setTerm(reportRequestDto.getTerm());
+        existingReport.setUserGrade(reportRequestDto.getUserGrade());
+        Report updatedReport = reportRepository.save(existingReport);
+        return convertToDto(updatedReport);
+    }
+
+    @Transactional
+    public ReportResponseDto.ReportScoreResponseDto updateReportScore(Long reportScoreId, ReportRequestDto.ReportScoreRequestDto scoreRequestDto) {
+        ReportScore existingReportScore = reportScoreRepository.findById(reportScoreId)
+                .orElseThrow(() -> new IllegalArgumentException("ReportScore not found with id: " + reportScoreId));
+        existingReportScore.setSubject(scoreRequestDto.getSubject());
+        existingReportScore.setGrade(scoreRequestDto.getGrade());
+        existingReportScore.setAchievement(scoreRequestDto.getAchievement());
+        existingReportScore.setRanking(scoreRequestDto.getRanking());
+        existingReportScore.setStudentNum(scoreRequestDto.getStudentNum());
+        existingReportScore.setStandardDeviation(scoreRequestDto.getStandardDeviation());
+        existingReportScore.setSubjectAverage(scoreRequestDto.getSubjectAverage());
+        existingReportScore.setScore(scoreRequestDto.getScore());
+        existingReportScore.setCredit(scoreRequestDto.getCredit());
+        ReportScore updatedReportScore = reportScoreRepository.save(existingReportScore);
+        return convertToDto(updatedReportScore);
+    }
+
+    @Transactional
+    public void deleteReport(Long reportId) {
+        reportRepository.deleteById(reportId);
+    }
+
+    private ReportResponseDto convertToDto(Report report) {
+        // ReportResponseDto의 생성자를 호출하여 엔티티를 넘겨줍니다.
+        return new ReportResponseDto(report);
+    }
+    private ReportResponseDto.ReportScoreResponseDto convertToDto(ReportScore reportScore) {
+        // ReportResponseDto의 생성자를 호출하여 엔티티를 넘겨줍니다.
+        return new ReportResponseDto.ReportScoreResponseDto(reportScore);
+    }
 }

--- a/src/main/java/hackerthon/likelion13th/canfly/login/controller/UserController.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/login/controller/UserController.java
@@ -5,6 +5,8 @@ import hackerthon.likelion13th.canfly.global.api.ApiResponse;
 import hackerthon.likelion13th.canfly.global.api.SuccessCode;
 import hackerthon.likelion13th.canfly.login.auth.dto.JwtDto;
 import hackerthon.likelion13th.canfly.login.auth.mapper.CustomUserDetails;
+import hackerthon.likelion13th.canfly.login.dto.CoinRequestDto;
+import hackerthon.likelion13th.canfly.login.dto.CoinResponseDto;
 import hackerthon.likelion13th.canfly.login.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -15,7 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
+import java.util.Map;
 
 @Tag(name = "회원", description = "회원 관련 api 입니다.")
 @RestController
@@ -58,6 +60,19 @@ public class UserController {
         return ApiResponse.onSuccess(SuccessCode.USER_DELETE_SUCCESS, 1);
     }
 
+    @Operation(summary = "토큰 사용 및 충전", description = "amount가 0이면 토큰 1개 사용, 0보다 크면 해당 양만큼 충전합니다.")
+    @PatchMapping("/token")
+    public ApiResponse<CoinResponseDto> updateUserCoins(
+            @AuthenticationPrincipal CustomUserDetails userDetails, // 또는 Authentication auth 객체
+            @RequestBody CoinRequestDto coinRequestDto) {
+        int amount = coinRequestDto.getAmount(); //내가 볼 때 그냥 token을 다른 테이블에 추가시키는 게 나음 ㅅ;ㅂ 이거 너무 많아 정보가
+        String username = userDetails.getUsername();
+        User updatedUser = userService.processCoins(username, amount);
+        CoinResponseDto responseDTO = CoinResponseDto.fromEntity(updatedUser);
+
+        // 3. 최종적으로 변환된 DTO를 클라이언트에게 전달합니다.
+        return ApiResponse.onSuccess(SuccessCode.TOKEN_PROCESS_SUCCESS, responseDTO);
+    }
     /*
     @Operation(summary = "프로필 사진 첨부", description = "프로필 사진을 첨부하는 메서드입니다.")
     @ApiResponses(value = {

--- a/src/main/java/hackerthon/likelion13th/canfly/login/dto/CoinRequestDto.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/login/dto/CoinRequestDto.java
@@ -1,0 +1,12 @@
+package hackerthon.likelion13th.canfly.login.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "for coin(token) DTO")
+@Getter
+@Setter
+public class CoinRequestDto {
+    private int amount;
+}

--- a/src/main/java/hackerthon/likelion13th/canfly/login/dto/CoinResponseDto.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/login/dto/CoinResponseDto.java
@@ -1,0 +1,17 @@
+package hackerthon.likelion13th.canfly.login.dto;
+
+import hackerthon.likelion13th.canfly.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CoinResponseDto {
+    private String username;
+    private int currentCoin; // 처리 후 최종 토큰 개수
+
+    // User 엔티티를 받아서 DTO로 변환해주는 정적 팩토리 메소드
+    public static CoinResponseDto fromEntity(User user) {
+        return new CoinResponseDto(user.getName(), user.getToken());
+    }
+}

--- a/src/main/java/hackerthon/likelion13th/canfly/login/repository/UserRepository.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/login/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package hackerthon.likelion13th.canfly.login.repository;
 
 import hackerthon.likelion13th.canfly.domain.user.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -20,5 +21,5 @@ public interface UserRepository extends JpaRepository<User, String> {
     // 4. 사용자 이메일을 가진 사용자 정보가 존재하는지 판단하는 기능
     boolean existsByEmail(String email);
 
-    User findByUid(String uid);
+    Optional<User> findByUid(String uid);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update
         default_batch_fetch_size: 1000
 ---
 # S3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create
         default_batch_fetch_size: 1000
 ---
 # S3


### PR DESCRIPTION
Achievement => String타입으로 결정
과목 카테고리(모의고사, 내신) => 정수형(Integer)
표준편차(standard_deviation) => Decimal타입에서 BigDecimal로 변경

Report 엔티티 주요 구조 변경:
학년(userGrade), 학기(term), 카테고리(Category)가 하나의 같은 테이블에 있음
<- ReportScore의 term 필드 삭제, Report의 userGrade 필드 추가
