### PR TITLE
can-fly -> can-fly2 update (.env file edit required)

### DIFF
--- a/src/main/java/hackerthon/likelion13th/canfly/global/config/SecurityConfig.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/global/config/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "http://127.0.0.1:3000", "https://can-fly.netlify.app"));
+        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "http://127.0.0.1:3000", "https://can-fly2.netlify.app"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);

--- a/src/main/java/hackerthon/likelion13th/canfly/global/config/WebConfig.java
+++ b/src/main/java/hackerthon/likelion13th/canfly/global/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**") // 애플리케이션의 모든 API 경로에 대해 CORS 설정을 적용합니다.
-                .allowedOrigins("http://localhost:8080", "http://127.0.0.1:8080", "http://localhost:3000", "http://127.0.0.1:3000", "https://can-fly.netlify.app/") // 로컬 환경의 Swagger UI
+                .allowedOrigins("http://localhost:8080", "http://127.0.0.1:8080", "http://localhost:3000", "http://127.0.0.1:3000", "https://can-fly2.netlify.app/") // 로컬 환경의 Swagger UI
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // 허용할 HTTP 메서드를 지정합니다.
                 .allowedHeaders("*") // 모든 HTTP 헤더를 허용합니다.
                 .allowCredentials(true); // 쿠키 및 인증 정보를 포함한 요청을 허용합니다.


### PR DESCRIPTION
프런트엔드 배포 주소가 달라짐에 따라 백엔드 주소를 바꿉니다.
업데이트된 파일은 총 3개입니다:
.env =>마지막 줄 FRONTEND_BASE_URL=https://can-fly2.netlify.app 로 변경합니다.
SecurityConfig.java => AllowedOriginPatterns에 기존 배포 주소를 "https://can-fly2.netlify.app"로 대체합니다.
WebConfig.java => allowedOrigins에 기존 배포 주소를 "https://can-fly2.netlify.app/"로 대체합니다.